### PR TITLE
Allow arbitrary desired capabilities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,5 @@ Specifies an assert module; to use within your tests
 Specifies a baseurl to be used within your tests
 ### properties
 Specifies a properties object; stick whatever you like in there
+### desiredCapabilities
+Desired Capabilities passed to Selenium; Arbitrary object whose keys are capability names.  Is merged with capabilites created for `browser` or can be used instead of `browser`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,13 +5,15 @@ var World = (function(seleniumAddress, options) {
 
   if (!seleniumAddress) throw new Error('Please provide a server url');
 
-  var browserOpt = options.browser || "chrome";
+  var desiredCapabilities = options.desiredCapabilities || {};
+  var browserOpt = options.browser || desiredCapabilities.browser || "chrome";
   var timeout = options.timeout || 100000;
 
   function World(callback) {
-    var driver = new webdriver.Builder()
+    var capabilities = webdriver.Capabilities[browserOpt]().merge(desiredCapabilities);
+    var driver = new webdriver.Builder(capabilities)
     .usingServer(seleniumAddress)
-    .withCapabilities(webdriver.Capabilities[browserOpt]())
+    .withCapabilities()
     .build();
 
     driver.manage().timeouts().setScriptTimeout(timeout);


### PR DESCRIPTION
selenium-webdriver allows for arbitrary desired capabilities to be set, but currently those can't be set when starting a driver.  By extracting `desiredCapabilities` from `options`, we can merge these with the nice default capabilities given to use by the selenium-webdriver module when required.

This change extracts `desiredCapabilities` where possible.  It also attempts to read `browser` from `desiredCapabilities` unless passed separately.  This extends the API for `World` without breaking it.