### PR TITLE
Corrected bug returning an empty object for the browser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,9 @@ var World = (function(seleniumAddress, options) {
 
   function World(callback) {
     var capabilities = webdriver.Capabilities[browserOpt]().merge(desiredCapabilities);
-    var driver = new webdriver.Builder(capabilities)
+    var driver = new webdriver.Builder()
     .usingServer(seleniumAddress)
-    .withCapabilities()
+    .withCapabilities(capabilities)
     .build();
 
     driver.manage().timeouts().setScriptTimeout(timeout);


### PR DESCRIPTION
Running cucumber.js was returning the following error when I was running the sample code:

events.js:72
        throw er; // Unhandled 'error' event
              ^
TypeError: Target browser must be a string, but is <object>; did you forget to call forBrowser()?
  at TypeError (<anonymous>:null:null)
  at [object Object].Builder.build (/home/kev/node_modules/selenium-webdriver/builder.js:407:11)
  at new World (/home/kev/node_modules/protractor-cucumber/lib/index.js:17:6)
  at Object.<anonymous> (/usr/lib/node_modules/cucumber/bin/cucumber.js:4:5)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Function.Module.runMain (module.js:497:10)
  at startup (node.js:119:16)
  at node.js:929:3

It turned out that the Builder constructor in Webdriver did not (or no longer) accepted parameters, but the withCapabilities() function did.