### PR TITLE
allowed direct connection from chromedriver to Chrome (without starting `webdriver-manager start` in other window)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ var steps = function() {
   var options = { browser : 'chrome', timeout : 100000 };
   this.World = pc.world(seleniumAddress, options);
 
-  this.After(function(callback) {
+  this.After(function(scenario, callback) {
     this.quit(callback);
   });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ var protractor = require('protractor')
 
 var World = (function(seleniumAddress, options) {
 
-  if (!seleniumAddress) throw new Error('Please provide a server url');
+  //if (!seleniumAddress) throw new Error('Please provide a server url');
 
   var desiredCapabilities = options.desiredCapabilities || {};
   var browserOpt = options.browser || desiredCapabilities.browser || "chrome";


### PR DESCRIPTION
allowed direct connection from chromedriver to Chrome (without starting `webdriver-manager start` in other window).
When `seleniumAddress` is empty in `webdriver.Builder().usingServer(seleniumAddress)` the direct connection is used. This is more convenient for local testing. So let's keep this possibility.
Thank you!
