### PR TITLE
Add support for protractor 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 protractor-cucumber
 ==============
 
-protractor-cucumber allows one to drive protractor tests using cucumber
+protractor-cucumber allows one to drive protractor tests using cucumber.
+
+## Support for protractor v4.x
+
+This repository is a fork of [AndrewKeig/protractor-cucumber](https://github.com/AndrewKeig/protractor-cucumber) that aims to support protractor version 4 and above.
+
+Feel free to contribute to it until it is merged into the original repo.
 
 ## Installation
 
@@ -63,7 +69,7 @@ Now create a feature file, `features/homepage.feature`
 
 ```
 
-Feature: Homepage 
+Feature: Homepage
   As a user
   I want to visit the homepage
   So that I can access the various features on offer
@@ -93,9 +99,9 @@ var steps = function() {
   this.Then(/^I should see a "([^"]*)" link$/, function(link, callback) {
     support.findByBinding(this, link, function(result){
       result.getText().then (function(text){
-        text.trim().toLowerCase().should.equal(link.trim().toLowerCase());             
+        text.trim().toLowerCase().should.equal(link.trim().toLowerCase());
         setTimeout(callback, 1000);
-      });     
+      });
     });
   });
 
@@ -155,7 +161,7 @@ module.exports = new Support();
 ```
 
 
-Now run cucumber: 
+Now run cucumber:
 
 ```
 cucumber.js
@@ -166,12 +172,12 @@ cucumber.js
 
 Below is a list of properties/methods exposed on the world object
 
-### browser 
+### browser
 a wrapper around an instance of webdriver. Used for navigation and page-wide information.
 ### protractor
 the protractor lib
 ### by
-a collection of element locator strategies. 
+a collection of element locator strategies.
 ### assert
 our chosen assertion library, not required is using `should`
 ### baseUrl

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,11 +27,11 @@ var World = (function(seleniumAddress, options) {
     if (options.baseUrl) this.baseUrl = options.baseUrl;
     if (options.properties) this.properties = options.properties;
 
-    this.quit = function(callback){
-      driver.quit().then(function(){
-        callback();
+    this.quit = function(callback) {
+      return driver.quit().then(function() {
+        if (callback) { callback(); }
       });
-    }
+    };
   }
 
   return World;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
-var protractor = require('protractor')
-, webdriver = require('selenium-webdriver');
+var protractor = require('protractor');
 
 var World = (function(seleniumAddress, options) {
 
@@ -10,23 +9,19 @@ var World = (function(seleniumAddress, options) {
   var timeout = options.timeout || 100000;
 
   function World() {
-    var capabilities = webdriver.Capabilities[browserOpt]().merge(desiredCapabilities);
-    var driver = new webdriver.Builder()
+    var capabilities = protractor.Capabilities[browserOpt]().merge(desiredCapabilities);
+    var driver = new protractor.Builder()
     .usingServer(seleniumAddress)
     .withCapabilities(capabilities)
     .build();
 
     driver.manage().timeouts().setScriptTimeout(timeout);
 
-    var winHandleBefore;
+    var browser = protractor.ProtractorBrowser.wrapDriver(driver);
 
-    driver.getWindowHandle().then(function(result){
-      winHandleBefore = result;
-    });
-
-    this.browser = protractor.wrapDriver(driver);
+    this.browser = browser;
     this.protractor = protractor;
-    this.by = protractor.By;
+    this.by = protractor.ProtractorBrowser.By;
 
     if (options.assert) this.assert = options.assert;
     if (options.baseUrl) this.baseUrl = options.baseUrl;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protractor-cucumber",
   "description": "Cucumber support for protractor",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "homepage": "https://github.com/andrewkeig/protractor-cucumber",
   "author": {
     "name": "Andrew Keig",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "async": ">=0.2.10",
-    "protractor": ">=1.6.0",
+    "protractor": ">=4.0.4",
     "cucumber": ">=0.8.0",
     "selenium-webdriver": ">=2.44.0"
   },


### PR DESCRIPTION
Some breaking changes have been introduced since protractor `4.0.0` that this PR fixes.

It also allows the user to return `this.quit()` since cucumberjs accepts promises instead of forcing the use of a callback.

Contributions to this fork are welcome until this has been merged here.
